### PR TITLE
Refactor cluster code to reduce number of variables

### DIFF
--- a/pathways/shipments.py
+++ b/pathways/shipments.py
@@ -299,7 +299,6 @@ def add_pest_clusters(config, shipment):
     cluster_sizes = _infested_stems_to_cluster_sizes(
         infested_stems, max_stems_per_cluster
     )
-    # print(cluster_sizes)
     for cluster_size in cluster_sizes:
         # Generate cluster as indices in the array of stems
         distribution = config["clustered"]["distribution"]


### PR DESCRIPTION
Determining sizes of clusters is now moved into a separate function.

In case another variable is added, this avoid Pylint:
R0914: Too many local variables (16/15) (too-many-locals)