### PR TITLE
Use SimpleNamespace to make return value less error prone

### DIFF
--- a/pathways/inspections.py
+++ b/pathways/inspections.py
@@ -265,12 +265,12 @@ def inspect(config, shipment, n_boxes_to_inspect):
     # Inspect selected boxes, count opened boxes, inspected stems, and infested stems
     # to detection and completion
     ret = types.SimpleNamespace(
-    boxes_opened_completion = n_boxes_to_inspect,
-    boxes_opened_detection = 0,
-    stems_inspected_completion = n_boxes_to_inspect * inspect_per_box,
-    stems_inspected_detection = 0,
-    infested_stems_completion = 0,
-    infested_stems_detection = 0,
+        boxes_opened_completion=n_boxes_to_inspect,
+        boxes_opened_detection=0,
+        stems_inspected_completion=n_boxes_to_inspect * inspect_per_box,
+        stems_inspected_detection=0,
+        infested_stems_completion=0,
+        infested_stems_detection=0,
     )
     detected = False
     for i in box_index_to_inspect:

--- a/pathways/inspections.py
+++ b/pathways/inspections.py
@@ -28,6 +28,7 @@ from __future__ import print_function, division
 
 import math
 import random
+import types
 import weakref
 import numpy as np
 
@@ -167,9 +168,9 @@ def sample_n(config, shipment):
     fixed_n = config["inspection"]["fixed_n"]
     unit = config["inspection"]["unit"]
     within_box_pct = config["inspection"]["within_box_pct"]
-    pathway = shipment["pathway"]
-    stems_per_box = config["stems_per_box"]
-    stems_per_box = get_stems_per_box(stems_per_box, pathway)
+    stems_per_box = get_stems_per_box(
+        config=config["stems_per_box"], pathway=shipment["pathway"]
+    )
     num_stems = shipment["num_stems"]
     num_boxes = shipment["num_boxes"]
     min_boxes = config.get("min_boxes", 1)
@@ -263,35 +264,30 @@ def inspect(config, shipment, n_boxes_to_inspect):
 
     # Inspect selected boxes, count opened boxes, inspected stems, and infested stems
     # to detection and completion
-    boxes_opened_completion = n_boxes_to_inspect
-    boxes_opened_detection = 0
-    stems_inspected_completion = n_boxes_to_inspect * inspect_per_box
-    stems_inspected_detection = 0
-    infested_stems_completion = 0
-    infested_stems_detection = 0
+    ret = types.SimpleNamespace(
+    boxes_opened_completion = n_boxes_to_inspect,
+    boxes_opened_detection = 0,
+    stems_inspected_completion = n_boxes_to_inspect * inspect_per_box,
+    stems_inspected_detection = 0,
+    infested_stems_completion = 0,
+    infested_stems_detection = 0,
+    )
     detected = False
     for i in box_index_to_inspect:
         if not detected:
-            boxes_opened_detection += 1
+            ret.boxes_opened_detection += 1
         for stem in (shipment["boxes"][i]).stems[0:inspect_per_box]:
             if not detected:
-                stems_inspected_detection += 1
+                ret.stems_inspected_detection += 1
             if stem:  # Count every infested stem in box, to completion within a box
-                infested_stems_completion += 1
+                ret.infested_stems_completion += 1
                 if not detected:
-                    infested_stems_detection += 1
-        if infested_stems_detection > 0:
+                    ret.infested_stems_detection += 1
+        if ret.infested_stems_detection > 0:
             detected = True
 
-    return (
-        infested_stems_completion == 0,
-        boxes_opened_completion,
-        boxes_opened_detection,
-        stems_inspected_completion,
-        stems_inspected_detection,
-        infested_stems_completion,
-        infested_stems_detection,
-    )
+    ret.shipment_checked_ok = ret.infested_stems_completion == 0
+    return ret
 
 
 def get_sample_function(config):

--- a/pathways/inspections.py
+++ b/pathways/inspections.py
@@ -168,9 +168,9 @@ def sample_n(config, shipment):
     fixed_n = config["inspection"]["fixed_n"]
     unit = config["inspection"]["unit"]
     within_box_pct = config["inspection"]["within_box_pct"]
-    stems_per_box = get_stems_per_box(
-        config=config["stems_per_box"], pathway=shipment["pathway"]
-    )
+    pathway = shipment["pathway"]
+    stems_per_box = config["stems_per_box"]
+    stems_per_box = get_stems_per_box(stems_per_box, pathway)
     num_stems = shipment["num_stems"]
     num_boxes = shipment["num_boxes"]
     min_boxes = config.get("min_boxes", 1)

--- a/pathways/simulation.py
+++ b/pathways/simulation.py
@@ -135,24 +135,17 @@ def simulation(
         )
         if must_inspect:
             n_boxes_to_inspect = sample(shipment)
-            (
-                shipment_checked_ok,
-                boxes_opened_completion,
-                boxes_opened_detection,
-                stems_inspected_completion,
-                stems_inspected_detection,
-                infested_stems_completion,
-                infested_stems_detection,
-            ) = inspect(config, shipment, n_boxes_to_inspect)
+            ret = inspect(config, shipment, n_boxes_to_inspect)
+            shipment_checked_ok = ret.shipment_checked_ok
             num_inspections += 1
             total_num_boxes += shipment["num_boxes"]
             total_num_stems += shipment["num_stems"]
-            total_boxes_opened_completion += boxes_opened_completion
-            total_boxes_opened_detection += boxes_opened_detection
-            total_stems_inspected_completion += stems_inspected_completion
-            total_stems_inspected_detection += stems_inspected_detection
-            total_infested_stems_completion += infested_stems_completion
-            total_infested_stems_detection += infested_stems_detection
+            total_boxes_opened_completion += ret.boxes_opened_completion
+            total_boxes_opened_detection += ret.boxes_opened_detection
+            total_stems_inspected_completion += ret.stems_inspected_completion
+            total_stems_inspected_detection += ret.stems_inspected_detection
+            total_infested_stems_completion += ret.infested_stems_completion
+            total_infested_stems_detection += ret.infested_stems_detection
         else:
             shipment_checked_ok = True  # assuming or hoping it's ok
             total_num_boxes += shipment["num_boxes"]


### PR DESCRIPTION
types.SimpleNamespace is now used for return value so that retrieving the values does not require
the caller to get the order right. The assignments are now more explicit and potentially more readable.

This also reduces number of variables in the inspect() function.