### PR TITLE
Simplify inspection function fix typo bug

### DIFF
--- a/pathways/inspections.py
+++ b/pathways/inspections.py
@@ -175,7 +175,9 @@ def sample_n(config, shipment):
     min_boxes = config.get("min_boxes", 1)
 
     if unit == "stems":
-        max_stems = compute_max_inspectable_stems(num_stems, stems_per_box, within_box_pct)
+        max_stems = compute_max_inspectable_stems(
+            num_stems, stems_per_box, within_box_pct
+        )
         # Check if max number of stems that can be inspected is less than fixed number.
         n_stems_to_inspect = min(max_stems, fixed_n)
         n_boxes_to_inspect = convert_stems_to_boxes(
@@ -213,22 +215,22 @@ def convert_stems_to_boxes(config, shipment, n_stems_to_inspect):
 
 
 def compute_max_inspectable_stems(num_stems, stems_per_box, within_box_pct):
-        """Compute maximum number of stems that can be inspected in a shipment based
-        on within box percent. If within box percent is less than 1 (partial box
-        inspections), then maximum number of stems that can be inspected will be
-        less than the total number of stems in the shipment.
+    """Compute maximum number of stems that can be inspected in a shipment based
+    on within box percent. If within box percent is less than 1 (partial box
+    inspections), then maximum number of stems that can be inspected will be
+    less than the total number of stems in the shipment.
 
-        :param num_stems: total number of stems in shipment
-        :param stems_per_box: number of stems in each box
-        :param within_box_pct: percentage of stems to be inspected per box
-        """
-        inspect_per_box = int(math.ceil(within_box_pct * stems_per_box))
-        num_full_boxes = math.floor(num_stems / stems_per_box)
-        full_box_inspectable_stems = num_full_boxes * inspect_per_box
-        remainder_box = num_stems % stems_per_box
-        remainder_box_inspectable_stems= min(remainder_box, inspect_per_box)
-        max_stems = full_box_inspectable_stems + remainder_box_inspectable_stems
-        return max_stems
+    :param num_stems: total number of stems in shipment
+    :param stems_per_box: number of stems in each box
+    :param within_box_pct: percentage of stems to be inspected per box
+    """
+    inspect_per_box = int(math.ceil(within_box_pct * stems_per_box))
+    num_full_boxes = math.floor(num_stems / stems_per_box)
+    full_box_inspectable_stems = num_full_boxes * inspect_per_box
+    remainder_box = num_stems % stems_per_box
+    remainder_box_inspectable_stems = min(remainder_box, inspect_per_box)
+    max_stems = full_box_inspectable_stems + remainder_box_inspectable_stems
+    return max_stems
 
 
 def inspect(config, shipment, n_boxes_to_inspect):

--- a/pathways/inspections.py
+++ b/pathways/inspections.py
@@ -175,15 +175,9 @@ def sample_n(config, shipment):
     min_boxes = config.get("min_boxes", 1)
 
     if unit == "stems":
-        inspect_per_box = int(math.ceil(within_box_pct * stems_per_box))
-        # Compute maximum num of stems that can be inspected in a ship based on
-        # within box percent.
-        full_box_inspect_stems = math.floor(num_stems / stems_per_box) * inspect_per_box
-        partial_box = num_stems % stems_per_box
-        partial_box_inspect_stems = min(partial_box, inspect_per_box)
-        max_stems = full_box_inspect_stems + partial_box_inspect_stems
-        n_stems_to_inspect = min(max_stems, fixed_n)
+        max_stems = compute_max_inspectable_stems(num_stems, stems_per_box, within_box_pct)
         # Check if max number of stems that can be inspected is less than fixed number.
+        n_stems_to_inspect = min(max_stems, fixed_n)
         n_boxes_to_inspect = convert_stems_to_boxes(
             config, shipment, n_stems_to_inspect
         )
@@ -216,6 +210,25 @@ def convert_stems_to_boxes(config, shipment, n_stems_to_inspect):
     n_boxes_to_inspect = max(min_boxes, n_boxes_to_inspect)
     n_boxes_to_inspect = min(num_boxes, n_boxes_to_inspect)
     return n_boxes_to_inspect
+
+
+def compute_max_inspectable_stems(num_stems, stems_per_box, within_box_pct):
+        """Compute maximum number of stems that can be inspected in a shipment based
+        on within box percent. If within box percent is less than 1 (partial box
+        inspections), then maximum number of stems that can be inspected will be
+        less than the total number of stems in the shipment.
+
+        :param num_stems: total number of stems in shipment
+        :param stems_per_box: number of stems in each box
+        :param within_box_pct: percentage of stems to be inspected per box
+        """
+        inspect_per_box = int(math.ceil(within_box_pct * stems_per_box))
+        num_full_boxes = math.floor(num_stems / stems_per_box)
+        full_box_inspectable_stems = num_full_boxes * inspect_per_box
+        remainder_box = num_stems % stems_per_box
+        remainder_box_inspectable_stems= min(remainder_box, inspect_per_box)
+        max_stems = full_box_inspectable_stems + remainder_box_inspectable_stems
+        return max_stems
 
 
 def inspect(config, shipment, n_boxes_to_inspect):

--- a/pathways/simulation.py
+++ b/pathways/simulation.py
@@ -120,7 +120,7 @@ def simulation(
     missed_infestation_rate = 0
 
     shipment_generator = get_shipment_generator(config)
-    add_pest = get_pest_function(config)
+    add_pest = get_pest_function(cofnfig)
     is_inspection_needed = get_inspection_needed_function(config)
     sample = get_sample_function(config)
 
@@ -198,7 +198,7 @@ def simulation(
         avg_stems_inspected_completion=total_stems_inspected_completion / num_shipments,
         avg_stems_inspected_detection=total_stems_inspected_detection / num_shipments,
         pct_stems_inspected_completion=(
-            total_stems_inspection_completion / total_num_stems
+            total_stems_inspected_completion / total_num_stems
         )
         * 100,
         pct_stems_inspected_detection=(
@@ -206,7 +206,7 @@ def simulation(
         )
         * 100,
         pct_sample_if_to_detection=(
-            total_stems_inspection_detection / total_stems_inspection_completion
+            total_stems_inspected_detection / total_stems_inspected_completion
         )
         * 100,
         pct_pest_unreported_if_detection=(

--- a/pathways/simulation.py
+++ b/pathways/simulation.py
@@ -120,7 +120,7 @@ def simulation(
     missed_infestation_rate = 0
 
     shipment_generator = get_shipment_generator(config)
-    add_pest = get_pest_function(cofnfig)
+    add_pest = get_pest_function(config)
     is_inspection_needed = get_inspection_needed_function(config)
     sample = get_sample_function(config)
 

--- a/pathways/simulation.py
+++ b/pathways/simulation.py
@@ -111,8 +111,8 @@ def simulation(
     total_num_stems = 0
     total_boxes_opened_completion = 0
     total_boxes_opened_detection = 0
-    total_stems_inspection_completion = 0
-    total_stems_inspection_detection = 0
+    total_stems_inspected_completion = 0
+    total_stems_inspected_detection = 0
     total_infested_stems_completion = 0
     total_infested_stems_detection = 0
     true_infestation_rate = 0


### PR DESCRIPTION
Addressed issue #16 and part of #17.

Was not able to reduce number of variables in inspect(). One idea is to use a dictionary or tuple to store the opened boxes and inspected stem counts for detection and completion. Let me know if you want me to pursue that.