### PR TITLE
Used fixed seed in the CLI test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,4 +69,7 @@ def run_pathways_cli(**kwargs):
 def test_gives_result(tmp_path):
     config = tmp_path / "config.yml"
     config.write_text(CONFIG)
-    assert "slippage" in run_pathways_cli(num_shipments=10, config_file=str(config))
+    for seed in range(10):
+        assert "slippage" in run_pathways_cli(
+            num_shipments=10, config_file=str(config), seed=seed
+        )


### PR DESCRIPTION
Test several different fixed seeds for greater robustness.
For example, as of a0e1f84, seed=1 passes tests while seed=2 fails.

Right now, tests sometimes pass and sometimes fail due to the random seed used. With this PR, they currently always fails, but the passing case is running too.