### PR TITLE
Use specific version of Pylint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         pip install .
     - name: Lint with Pylint
       run: |
-        pip install pylint
+        pip install pylint==2.4.4
         pylint pathways
 
   black-code-style:


### PR DESCRIPTION
This avoids surprises in CI. Upgrade needs to be manual now.