### PR TITLE
Add configuration for --pretty to avoid Unicode trouble

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ pretty:
   flower: o
   bug: x
   horizontal_line: "-"
+  box_line: "|"
 ```
 
 Setting like the above can allow you to use `--pretty` even when unicode

--- a/README.md
+++ b/README.md
@@ -412,6 +412,23 @@ inspection:
   first_n_boxes: 2
 ```
 
+### Outputs
+
+Pretty printing enabled by `--pretty` in the command line can be further
+configured using `pretty` key in the configuration file:
+
+```
+pretty:
+  flower: o
+  bug: x
+  horizontal_line: "-"
+```
+
+Setting like the above can allow you to use `--pretty` even when unicode
+is not properly displayed in your terminal. Note that some characters,
+such as the dash (`-`) above, need to be in quotes because they have
+a special meaning in YAML.
+
 ### Obtaining pre-computed sample database records
 
 #### Download using a web browser

--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ pretty:
   bug: x
   horizontal_line: "-"
   box_line: "|"
+  spaces: false
 ```
 
 Setting like the above can allow you to use `--pretty` even when unicode

--- a/config.yml
+++ b/config.yml
@@ -76,7 +76,3 @@ stems_per_box:
     default: 20
   maritime:
     default: 30
-pretty:
-  flower: o
-  bug: x
-  horizontal_line: "-"

--- a/config.yml
+++ b/config.yml
@@ -76,3 +76,7 @@ stems_per_box:
     default: 20
   maritime:
     default: 30
+pretty:
+  flower: o
+  bug: x
+  horizontal_line: "-"

--- a/pathways/outputs.py
+++ b/pathways/outputs.py
@@ -90,43 +90,45 @@ def pretty_header(shipment, line=None, config={}):  # pylint: disable=unused-arg
     return "{header}{rule}".format(**locals())
 
 
-def pretty_print_shipment_stems(shipment, config={}):
+def pretty_shipment_stems(shipment, config={}):
     """Pretty-print shipment focusing on individual stems"""
-    print(pretty_header(shipment, config=config))
-    print(pretty_content(shipment["stems"], config=config))
+    header = pretty_header(shipment, config=config)
+    body = pretty_content(shipment["stems"], config=config)
+    return "{header}\n{body}".format(**locals())
 
 
-def pretty_print_shipment_boxes(shipment, config={}):
+def pretty_shipment_boxes(shipment, config={}):
     """Pretty-print shipment showing individual stems in boxes"""
-    print(pretty_header(shipment, config=config))
+    header = pretty_header(shipment, config=config)
     line = config.get("box_line", "|")
     if line == "pipe":
         line = "|"
     separator = " {} ".format(line)
-    print(
-        separator.join(
-            [pretty_content(box.stems, config=config) for box in shipment["boxes"]]
-        )
+    body = separator.join(
+        [pretty_content(box.stems, config=config) for box in shipment["boxes"]]
     )
+    return "{header}\n{body}".format(**locals())
 
 
-def pretty_print_shipment_boxes_only(shipment, config={}):
+def pretty_shipment_boxes_only(shipment, config={}):
     """Pretty-print shipment showing individual boxes"""
-    print(pretty_header(shipment, line="light", config=config))
-    print(pretty_content(shipment["boxes"], config=config))
+    line = config.get("horizontal_line", "light")
+    header = pretty_header(shipment, line=line, config=config)
+    body = pretty_content(shipment["boxes"], config=config)
+    return "{header}\n{body}".format(**locals())
 
 
-def pretty_print_shipment(shipment, style, config={}):
+def pretty_print_shipment(shipment, style, config={}, file=None):
     """Pretty-print shipment in a given style
 
     :param style: Style of pretty-printing (boxes, boxes_only, stems)
     """
     if style == "boxes":
-        pretty_print_shipment_boxes(shipment, config=config)
+        print(pretty_shipment_boxes(shipment, config=config))
     elif style == "boxes_only":
-        pretty_print_shipment_boxes_only(shipment, config=config)
+        print(pretty_shipment_boxes_only(shipment, config=config))
     elif style == "stems":
-        pretty_print_shipment_stems(shipment, config=config)
+        print(pretty_shipment_stems(shipment, config=config))
     else:
         raise ValueError(
             "Unknown style value for pretty printing of shipments: {pretty}".format(

--- a/pathways/outputs.py
+++ b/pathways/outputs.py
@@ -36,11 +36,12 @@ if not hasattr(weakref, "finalize"):
     from backports import weakref  # pylint: disable=import-error
 
 
-def pretty_content(array, config={}):
+def pretty_content(array, config=None):
     """Return string with array content nicelly visualized as unicode text
 
     Values evaluating to False are replaced with a flower, others with a bug.
     """
+    config = config if config else {}
     flower_sign = config.get("flower", "\N{Black Florette}")
     bug_sign = config.get("bug", "\N{Bug}")
     spaces = config.get("spaces", True)
@@ -59,14 +60,15 @@ def pretty_content(array, config={}):
     return separator.join(pretty)
 
 
-# Pylint does not see usage of a variables in a format string.
-def pretty_header(shipment, line=None, config={}):  # pylint: disable=unused-argument
+# Pylint 2.4.4 does not see usage of a variables in a format string.
+def pretty_header(shipment, line=None, config=None):  # pylint: disable=unused-argument
     """Return header for a shipment
 
     Basic info about the shipment is included and the remainining space
     in a terminal window is filled with horizonal box characters.
     (The assumption is that this will be printed in the terminal.)
     """
+    config = config if config else {}
     size = 80
     if hasattr(shutil, "get_terminal_size"):
         size = shutil.get_terminal_size().columns
@@ -95,16 +97,18 @@ def pretty_header(shipment, line=None, config={}):  # pylint: disable=unused-arg
     return "{header}{rule}".format(**locals())
 
 
-def pretty_shipment_stems(shipment, config={}):
+def pretty_shipment_stems(shipment, config=None):
     """Pretty-print shipment focusing on individual stems"""
+    config = config if config else {}
+    # pylint: disable=possibly-unused-variable
     header = pretty_header(shipment, config=config)
     body = pretty_content(shipment["stems"], config=config)
     return "{header}\n{body}".format(**locals())
 
 
-def pretty_shipment_boxes(shipment, config={}):
+def pretty_shipment_boxes(shipment, config=None):
     """Pretty-print shipment showing individual stems in boxes"""
-    header = pretty_header(shipment, config=config)
+    config = config if config else {}
     line = config.get("box_line", "|")
     spaces = config.get("spaces", True)
     if line == "pipe":
@@ -113,25 +117,30 @@ def pretty_shipment_boxes(shipment, config={}):
         separator = " {} ".format(line)
     else:
         separator = line
+    # pylint: disable=possibly-unused-variable
+    header = pretty_header(shipment, config=config)
     body = separator.join(
         [pretty_content(box.stems, config=config) for box in shipment["boxes"]]
     )
     return "{header}\n{body}".format(**locals())
 
 
-def pretty_shipment_boxes_only(shipment, config={}):
+def pretty_shipment_boxes_only(shipment, config=None):
     """Pretty-print shipment showing individual boxes"""
+    config = config if config else {}
+    # pylint: disable=possibly-unused-variable
     line = config.get("horizontal_line", "light")
     header = pretty_header(shipment, line=line, config=config)
     body = pretty_content(shipment["boxes"], config=config)
     return "{header}\n{body}".format(**locals())
 
 
-def pretty_print_shipment(shipment, style, config={}, file=None):
+def pretty_print_shipment(shipment, style, config=None, file=None):
     """Pretty-print shipment in a given style
 
     :param style: Style of pretty-printing (boxes, boxes_only, stems)
     """
+    config = config if config else {}
     if style == "boxes":
         print(pretty_shipment_boxes(shipment, config=config))
     elif style == "boxes_only":

--- a/pathways/outputs.py
+++ b/pathways/outputs.py
@@ -135,7 +135,7 @@ def pretty_shipment_boxes_only(shipment, config=None):
     return "{header}\n{body}".format(**locals())
 
 
-def pretty_print_shipment(shipment, style, config=None):
+def pretty_shipment(shipment, style, config=None):
     """Pretty-print shipment in a given style
 
     :param style: Style of pretty-printing (boxes, boxes_only, stems)

--- a/pathways/outputs.py
+++ b/pathways/outputs.py
@@ -36,24 +36,26 @@ if not hasattr(weakref, "finalize"):
     from backports import weakref  # pylint: disable=import-error
 
 
-def pretty_content(array):
+def pretty_content(array, config={}):
     """Return string with array content nicelly visualized as unicode text
 
     Values evaluating to False are replaced with a flower, others with a bug.
     """
+    flower_sign = config.get("flower", "\N{Black Florette}")
+    bug_sign = config.get("bug", "\N{Bug}")
 
     def replace(number):
         if number:
-            return "\N{Bug}"
+            return bug_sign
         else:
-            return "\N{Black Florette}"
+            return flower_sign
 
     pretty = [replace(i) for i in array]
     return " ".join(pretty)
 
 
 # Pylint does not see usage of a variables in a format string.
-def pretty_header(shipment, line="heavy"):  # pylint: disable=unused-argument
+def pretty_header(shipment, line=None, config={}):  # pylint: disable=unused-argument
     """Return header for a shipment
 
     Basic info about the shipment is included and the remainining space
@@ -63,6 +65,9 @@ def pretty_header(shipment, line="heavy"):  # pylint: disable=unused-argument
     size = 80
     if hasattr(shutil, "get_terminal_size"):
         size = shutil.get_terminal_size().columns
+    if line is None:
+        # We test None but not for "" to allow use of an empty string.
+        line = config.get("horizontal_line", "heavy")
     if line.lower() == "heavy":
         horizontal = "\N{Box Drawings Heavy Horizontal}"
     elif line.lower() == "light":
@@ -85,35 +90,39 @@ def pretty_header(shipment, line="heavy"):  # pylint: disable=unused-argument
     return "{header}{rule}".format(**locals())
 
 
-def pretty_print_shipment_stems(shipment):
+def pretty_print_shipment_stems(shipment, config={}):
     """Pretty-print shipment focusing on individual stems"""
-    print(pretty_header(shipment))
-    print(pretty_content(shipment["stems"]))
+    print(pretty_header(shipment, config=config))
+    print(pretty_content(shipment["stems"], config=config))
 
 
-def pretty_print_shipment_boxes(shipment):
+def pretty_print_shipment_boxes(shipment, config={}):
     """Pretty-print shipment showing individual stems in boxes"""
-    print(pretty_header(shipment))
-    print(" | ".join([pretty_content(box.stems) for box in shipment["boxes"]]))
+    print(pretty_header(shipment, config=config))
+    print(
+        " | ".join(
+            [pretty_content(box.stems, config=config) for box in shipment["boxes"]]
+        )
+    )
 
 
-def pretty_print_shipment_boxes_only(shipment):
+def pretty_print_shipment_boxes_only(shipment, config={}):
     """Pretty-print shipment showing individual boxes"""
-    print(pretty_header(shipment, line="light"))
-    print(pretty_content(shipment["boxes"]))
+    print(pretty_header(shipment, line="light", config=config))
+    print(pretty_content(shipment["boxes"], config=config))
 
 
-def pretty_print_shipment(shipment, style):
+def pretty_print_shipment(shipment, style, config={}):
     """Pretty-print shipment in a given style
 
     :param style: Style of pretty-printing (boxes, boxes_only, stems)
     """
     if style == "boxes":
-        pretty_print_shipment_boxes(shipment)
+        pretty_print_shipment_boxes(shipment, config=config)
     elif style == "boxes_only":
-        pretty_print_shipment_boxes_only(shipment)
+        pretty_print_shipment_boxes_only(shipment, config=config)
     elif style == "stems":
-        pretty_print_shipment_stems(shipment)
+        pretty_print_shipment_stems(shipment, config=config)
     else:
         raise ValueError(
             "Unknown style value for pretty printing of shipments: {pretty}".format(

--- a/pathways/outputs.py
+++ b/pathways/outputs.py
@@ -135,18 +135,18 @@ def pretty_shipment_boxes_only(shipment, config=None):
     return "{header}\n{body}".format(**locals())
 
 
-def pretty_print_shipment(shipment, style, config=None, file=None):
+def pretty_print_shipment(shipment, style, config=None):
     """Pretty-print shipment in a given style
 
     :param style: Style of pretty-printing (boxes, boxes_only, stems)
     """
     config = config if config else {}
     if style == "boxes":
-        print(pretty_shipment_boxes(shipment, config=config))
+        return pretty_shipment_boxes(shipment, config=config)
     elif style == "boxes_only":
-        print(pretty_shipment_boxes_only(shipment, config=config))
+        return pretty_shipment_boxes_only(shipment, config=config)
     elif style == "stems":
-        print(pretty_shipment_stems(shipment, config=config))
+        return pretty_shipment_stems(shipment, config=config)
     else:
         raise ValueError(
             "Unknown style value for pretty printing of shipments: {pretty}".format(

--- a/pathways/outputs.py
+++ b/pathways/outputs.py
@@ -99,8 +99,12 @@ def pretty_print_shipment_stems(shipment, config={}):
 def pretty_print_shipment_boxes(shipment, config={}):
     """Pretty-print shipment showing individual stems in boxes"""
     print(pretty_header(shipment, config=config))
+    line = config.get("box_line", "|")
+    if line == "pipe":
+        line = "|"
+    separator = " {} ".format(line)
     print(
-        " | ".join(
+        separator.join(
             [pretty_content(box.stems, config=config) for box in shipment["boxes"]]
         )
     )

--- a/pathways/outputs.py
+++ b/pathways/outputs.py
@@ -43,6 +43,11 @@ def pretty_content(array, config={}):
     """
     flower_sign = config.get("flower", "\N{Black Florette}")
     bug_sign = config.get("bug", "\N{Bug}")
+    spaces = config.get("spaces", True)
+    if spaces:
+        separator = " "
+    else:
+        separator = ""
 
     def replace(number):
         if number:
@@ -51,7 +56,7 @@ def pretty_content(array, config={}):
             return flower_sign
 
     pretty = [replace(i) for i in array]
-    return " ".join(pretty)
+    return separator.join(pretty)
 
 
 # Pylint does not see usage of a variables in a format string.
@@ -101,9 +106,13 @@ def pretty_shipment_boxes(shipment, config={}):
     """Pretty-print shipment showing individual stems in boxes"""
     header = pretty_header(shipment, config=config)
     line = config.get("box_line", "|")
+    spaces = config.get("spaces", True)
     if line == "pipe":
         line = "|"
-    separator = " {} ".format(line)
+    if spaces:
+        separator = " {} ".format(line)
+    else:
+        separator = line
     body = separator.join(
         [pretty_content(box.stems, config=config) for box in shipment["boxes"]]
     )

--- a/pathways/simulation.py
+++ b/pathways/simulation.py
@@ -104,7 +104,7 @@ def simulation(
         add_pest(shipment)
         if pretty:
             pretty_config = config.get("pretty", {})
-            pretty_print_shipment(shipment, style=pretty, config=pretty_config)
+            print(pretty_print_shipment(shipment, style=pretty, config=pretty_config))
 
         must_inspect, applied_program = is_inspection_needed(
             shipment, shipment["arrival_time"]

--- a/pathways/simulation.py
+++ b/pathways/simulation.py
@@ -104,7 +104,7 @@ def simulation(
         add_pest(shipment)
         if pretty:
             pretty_config = config.get("pretty", {})
-            print(pretty_print_shipment(shipment, style=pretty, config=pretty_config))
+            print(pretty_shipment(shipment, style=pretty, config=pretty_config))
 
         must_inspect, applied_program = is_inspection_needed(
             shipment, shipment["arrival_time"]

--- a/pathways/simulation.py
+++ b/pathways/simulation.py
@@ -103,7 +103,8 @@ def simulation(
         shipment = shipment_generator.generate_shipment()
         add_pest(shipment)
         if pretty:
-            pretty_print_shipment(shipment, style=pretty)
+            pretty_config = config.get("pretty", {})
+            pretty_print_shipment(shipment, style=pretty, config=pretty_config)
 
         must_inspect, applied_program = is_inspection_needed(
             shipment, shipment["arrival_time"]

--- a/pathways/simulation.py
+++ b/pathways/simulation.py
@@ -48,7 +48,7 @@ from .outputs import (
     PrintReporter,
     MuteReporter,
     SuccessRates,
-    pretty_print_shipment,
+    pretty_shipment,
 )
 
 


### PR DESCRIPTION
Possible output:
```
-- Shipment -- Boxes: 10 -- Stems: 100 ----------
o o x o x o o o o o | o x x x o o o o o o | o o o o o o o o o o | o o o o o o o o o o 
```