### PR TITLE
Fix Black formatting

### DIFF
--- a/pathways/simulation.py
+++ b/pathways/simulation.py
@@ -155,9 +155,7 @@ def simulation(
 
     if success_rates.false_negative:
         false_negative_present = True
-        missed_infestation_rate = (
-            missed_infestation_rate / success_rates.false_negative
-        )
+        missed_infestation_rate = missed_infestation_rate / success_rates.false_negative
     else:
         false_negative_present = False
         missed_infestation_rate = 0
@@ -168,9 +166,8 @@ def simulation(
             intercepted_infestation_rate / success_rates.true_positive
         )
         pct_pest_unreported_if_detection = (
-            (1 - (total_infested_stems_detection / total_infested_stems_completion))
-            * 100
-        )
+            1 - (total_infested_stems_detection / total_infested_stems_completion)
+        ) * 100
     else:
         true_positive_present = False
         intercepted_infestation_rate = 0


### PR DESCRIPTION
In the first case, the stmt is short enough to fit on one line.
In the second case, just using whatever black generates, although it
is not ideal. The stmt is too long even when additional () are placed
around it, so that's why black reformats.