### PR TITLE
Add missing doc for --pretty in readme and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,8 +415,18 @@ inspection:
 
 ### Outputs
 
-Pretty printing enabled by `--pretty` in the command line can be further
-configured using `pretty` key in the configuration file:
+Pretty printing of individual shipments and stems can be enabled by
+`--pretty` in the command line with output like this:
+
+```
+━━ Shipment ━━ Boxes: 3 ━━ Stems: 30 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🐛 ✿ ✿ ✿ ✿ ✿ ✿ 🐛 ✿ ✿ | ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ 🐛 | ✿ ✿ 🐛 ✿ ✿ ✿ ✿ ✿ ✿ 🐛
+━━ Shipment ━━ Boxes: 2 ━━ Stems: 20 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🐛 ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ | ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ 🐛
+```
+
+This can be further configured using `pretty` key in the configuration
+file:
 
 ```
 pretty:
@@ -427,10 +437,19 @@ pretty:
   spaces: false
 ```
 
-Setting like the above can allow you to use `--pretty` even when unicode
-is not properly displayed in your terminal. Note that some characters,
-such as the dash (`-`) above, need to be in quotes because they have
-a special meaning in YAML.
+Configuration like the above can allow you to use `--pretty` even when
+Unicode characters are properly displayed in your terminal. Note that
+some characters, such as the dash (`-`) above, need to be in quotes
+because they have a special meaning in YAML.
+
+The output with the settings above will look like:
+
+```
+-- Shipment -- Boxes: 4 -- Stems: 40 -----------------------------------
+xooooooooo|ooooooxooo|oooooooooo|xoooooooox
+-- Shipment -- Boxes: 6 -- Stems: 60 -----------------------------------
+xxooooooxx|oooooooooo|oooxooooxx|ooooooooxo|ooooxooooo|ooooxoooox
+```
 
 ### Obtaining pre-computed sample database records
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/ncsu-landscape-dynamics/pathways-simulation/workflows/CI/badge.svg)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncsu-landscape-dynamics/pathways-simulation/master??urlpath=lab/tree/example.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncsu-landscape-dynamics/pathways-simulation/master?urlpath=lab/tree/example.ipynb)
 
 Simulation for evaluation of pathways which generates synthetic shipment
 data and performs inspection on them. It is using the following model

--- a/README.md
+++ b/README.md
@@ -425,6 +425,28 @@ Pretty printing of individual shipments and stems can be enabled by
 🐛 ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ | ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ 🐛
 ```
 
+Th above is the default output (equivalent with `--pretty=boxes`).
+Separation of individual boxes can be disabled using `--pretty=stems`
+where the only unit shown graphically are the stems. Possible output
+looks like this:
+
+```
+━━ Shipment ━━ Boxes: 3 ━━ Stems: 30 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🐛 ✿ ✿ 🐛 ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ 🐛
+━━ Shipment ━━ Boxes: 2 ━━ Stems: 20 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ ✿ 🐛
+```
+
+Finally, option `--pretty=boxes_only` focuses just on the boxes and does
+not show individual stems:
+
+```
+── Shipment ── Boxes: 6 ── Stems: 60 ───────────────────────────────────
+🐛 🐛 ✿ ✿ ✿ 🐛
+── Shipment ── Boxes: 4 ── Stems: 40 ───────────────────────────────────
+✿ ✿ ✿ 🐛
+```
+
 This can be further configured using `pretty` key in the configuration
 file:
 


### PR DESCRIPTION
Show examples of command line options for pretty printing
and provide brief description in readme.
Include example for simple ASCII configuration of pretty.
Fix typo in Binder URL.
