### PR TITLE
Return only result from one simulation, but add config for scenario

### DIFF
--- a/pathways/app.py
+++ b/pathways/app.py
@@ -126,8 +126,9 @@ def main():
     )
     args = parser.parse_args()
 
-    totals, sim_params = run_simulation(
-        config=load_configuration(args.config_file),
+    config = load_configuration(args.config_file)
+    totals = run_simulation(
+        config=config,
         num_simulations=args.num_simulations,
         num_shipments=args.num_shipments,
         seed=args.seed,
@@ -135,7 +136,7 @@ def main():
         verbose=args.verbose,
         pretty=args.pretty,
     )
-    print_totals_as_text(args.num_shipments, sim_params, totals)
+    print_totals_as_text(args.num_shipments, config, totals)
 
 
 if __name__ == "__main__":

--- a/pathways/outputs.py
+++ b/pathways/outputs.py
@@ -29,6 +29,7 @@ from __future__ import print_function, division
 import shutil
 import weakref
 import csv
+import types
 
 from .inspections import count_diseased_boxes
 
@@ -310,8 +311,59 @@ class SuccessRates(object):
             )
 
 
-def print_totals_as_text(num_shipments, sim_params, totals):
+def config_to_simplified_simulation_params(config):
+    """Convert configuration into a simplified set of selected parameters"""
+    sim_params = types.SimpleNamespace(
+        infestation_type="",
+        infestation_param="",
+        pest_arrangement="",
+        max_stems_per_cluster="",
+        cluster_width="",
+        inspection_unit="",
+        within_box_pct="",
+        sample_strategy="",
+        sample_params="",
+        selection_strategy="",
+    )
+
+    sim_params.infestation_type = config["pest"]["infestation_rate"]["distribution"]
+    if sim_params.infestation_type == "fixed_value":
+        sim_params.infestation_param = config["pest"]["infestation_rate"]["value"]
+    elif sim_params.infestation_type == "beta":
+        sim_params.infestation_param = config["pest"]["infestation_rate"]["parameters"]
+    else:
+        sim_params.infestation_param = None
+    sim_params.pest_arrangement = config["pest"]["arrangement"]
+    if sim_params.pest_arrangement == "clustered":
+        sim_params.max_stems_per_cluster = config["pest"]["clustered"][
+            "max_stems_per_cluster"
+        ]
+        sim_params.cluster_width = config["pest"]["clustered"]["parameters"][0]
+    else:
+        sim_params.max_stems_per_cluster = None
+        sim_params.cluster_width = None
+    sim_params.inspection_unit = config["inspection"]["unit"]
+    sim_params.within_box_pct = config["inspection"]["within_box_pct"]
+    sim_params.sample_strategy = config["inspection"]["sample_strategy"]
+    if sim_params.sample_strategy == "percentage":
+        sim_params.sample_params = config["inspection"]["percentage"]["proportion"]
+    elif sim_params.sample_strategy == "hypergeometric":
+        sim_params.sample_params = config["inspection"]["hypergeometric"][
+            "detection_level"
+        ]
+    elif sim_params.sample_strategy == "fixed_n":
+        sim_params.sample_params = config["inspection"]["fixed_n"]
+    else:
+        sim_params.sample_params = None
+    sim_params.selection_strategy = config["inspection"]["selection_strategy"]
+
+    return sim_params
+
+
+def print_totals_as_text(num_shipments, config, totals):
     """Prints simulation result as text"""
+    sim_params = config_to_simplified_simulation_params(config)
+
     # "On average, inspecting {0:.0f}% of shipments.".format(
     #    100 * totals.num_inspections / float(args.num_shipments))
     print("\n")

--- a/pathways/scenarios.py
+++ b/pathways/scenarios.py
@@ -103,8 +103,9 @@ def run_scenarios(config, scenario_table, seed, num_simulations, num_shipments):
 
     Returns
     -------
-    results : list
-        List of results with one item for each scenario.
+    results : list of tuples
+        List of results with one tuple for each scenario. One tuple contains simulation
+        result and configuration for that scenario.
     """
     results = []
     for record in scenario_table:
@@ -115,7 +116,7 @@ def run_scenarios(config, scenario_table, seed, num_simulations, num_shipments):
             num_shipments=num_shipments,
             seed=seed,
         )
-        results.append(result)
+        results.append((result, scenario_config))
     return results
 
 

--- a/pathways/simulation.py
+++ b/pathways/simulation.py
@@ -302,51 +302,7 @@ def run_simulation(
     else:
         totals.intercepted_infestation_rate = None
 
-    sim_params = types.SimpleNamespace(
-        infestation_type="",
-        infestation_param="",
-        pest_arrangement="",
-        max_stems_per_cluster="",
-        cluster_width="",
-        inspection_unit="",
-        within_box_pct="",
-        sample_strategy="",
-        sample_params="",
-        selection_strategy="",
-    )
-
-    sim_params.infestation_type = config["pest"]["infestation_rate"]["distribution"]
-    if sim_params.infestation_type == "fixed_value":
-        sim_params.infestation_param = config["pest"]["infestation_rate"]["value"]
-    elif sim_params.infestation_type == "beta":
-        sim_params.infestation_param = config["pest"]["infestation_rate"]["parameters"]
-    else:
-        sim_params.infestation_param = None
-    sim_params.pest_arrangement = config["pest"]["arrangement"]
-    if sim_params.pest_arrangement == "clustered":
-        sim_params.max_stems_per_cluster = config["pest"]["clustered"][
-            "max_stems_per_cluster"
-        ]
-        sim_params.cluster_width = config["pest"]["clustered"]["parameters"][0]
-    else:
-        sim_params.max_stems_per_cluster = None
-        sim_params.cluster_width = None
-    sim_params.inspection_unit = config["inspection"]["unit"]
-    sim_params.within_box_pct = config["inspection"]["within_box_pct"]
-    sim_params.sample_strategy = config["inspection"]["sample_strategy"]
-    if sim_params.sample_strategy == "percentage":
-        sim_params.sample_params = config["inspection"]["percentage"]["proportion"]
-    elif sim_params.sample_strategy == "hypergeometric":
-        sim_params.sample_params = config["inspection"]["hypergeometric"][
-            "detection_level"
-        ]
-    elif sim_params.sample_strategy == "fixed_n":
-        sim_params.sample_params = config["inspection"]["fixed_n"]
-    else:
-        sim_params.sample_params = None
-    sim_params.selection_strategy = config["inspection"]["selection_strategy"]
-
-    return totals, sim_params
+    return totals
 
 
 def load_configuration_yaml_from_text(text):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,6 +69,6 @@ def test_gives_result(tmp_path):
     config = tmp_path / "config.yml"
     config.write_text(CONFIG)
     for seed in range(10):
-        assert "slippage" in run_pathways_cli(
+        assert "slipped" in run_pathways_cli(
             num_shipments=10, config_file=str(config), seed=seed
         )


### PR DESCRIPTION
No reason to return just a restructured config which is input, so return only result from one simulation.

Scenario run creates config by combining multiple sources, so return the full config.

Separate the simplification of config to a function. Closes #49 although it leaves in the simplification.