### PR TITLE
Specify CSV format

### DIFF
--- a/pathways/outputs.py
+++ b/pathways/outputs.py
@@ -471,7 +471,14 @@ def save_scenario_result_to_table(filename, results, config_columns, result_colu
     in format key/subkey/subsubkey.
     """
     with open(filename, "w") as file:
-        writer = csv.DictWriter(file, config_columns + result_columns)
+        writer = csv.DictWriter(
+            file,
+            config_columns + result_columns,
+            delimiter=",",
+            quotechar='"',
+            lineterminator="\n",
+            quoting=csv.QUOTE_MINIMAL,
+        )
         writer.writeheader()
         for result, config in results:
             row = {}


### PR DESCRIPTION
On Windows, writer ends up writing two newline without an explicit settings.
