### PR TITLE
Fix linter errors in tests, consignments, ignore 3 in consignments, outputs

### DIFF
--- a/pathways/consignments.py
+++ b/pathways/consignments.py
@@ -70,6 +70,8 @@ class Consignment(collections.UserDict):
 
     # Inheriting from this library class is its intended use, so disable ancestors msg.
     # pylint: disable=too-many-ancestors
+    # This class is meant to hold a lot of attributes.
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(
         self,
@@ -96,6 +98,7 @@ class Consignment(collections.UserDict):
         :param port: string
         :param pathway: string
         """
+        super().__init__()
         self.flower = flower
         self.num_items = num_items
         self.items = items

--- a/pathways/outputs.py
+++ b/pathways/outputs.py
@@ -391,6 +391,9 @@ def config_to_simplified_simulation_params(config):
 
 def print_totals_as_text(num_consignments, config, totals):
     """Prints simulation result as text"""
+    # This is straightforward printing with simpler branches. Only few variables.
+    # pylint: disable=too-many-branches,too-many-statements
+
     sim_params = config_to_simplified_simulation_params(config)
 
     # "On average, inspecting {0:.0f}% of consignments.".format(100 *

--- a/tests/test_run_simulation.py
+++ b/tests/test_run_simulation.py
@@ -75,7 +75,7 @@ def test_gives_reasonable_result(num_simulations):
     config["consignment"]["boxes"]["max"] = max_boxes
     for seed in range(10):
         result = run_simulation(
-            config=config, num_simulations=1, num_consignments=100, seed=seed,
+            config=config, num_simulations=1, num_consignments=100, seed=seed
         )
         test_min_boxes = min_boxes * num_consignments
         test_max_boxes = max_boxes * num_consignments


### PR DESCRIPTION
The code flagged by Pylint is acceptable in these cases, super init is now called, Black is fixed.
