### PR TITLE
Split and update tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         pip install black
         black --check --diff .
 
-  test-scripts:
+  tests:
 
     runs-on: ubuntu-20.04
     strategy:
@@ -102,7 +102,7 @@ jobs:
       run: |
         pytest tests/
 
-  tests:
+  test-scripts:
 
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         pip install black
         black --check --diff .
 
-  test-:
+  test-scripts:
 
     runs-on: ubuntu-20.04
     strategy:
@@ -102,7 +102,7 @@ jobs:
       run: |
         pytest tests/
 
-  test:
+  tests:
 
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,18 +79,41 @@ jobs:
         pip install black
         black --check --diff .
 
-  test:
+  test-:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+        pip install pytest pytest-datadir
+    - name: Test with pytest
+      run: |
+        pytest tests/
+
+  test:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install
@@ -100,7 +123,3 @@ jobs:
     - name: Basic test
       run: |
         python -m pathways --num-simulations 5 --num-consignments 50 --config-file config.yml
-    - name: Test with pytest
-      run: |
-        pip install pytest pytest-datadir
-        pytest tests/


### PR DESCRIPTION
Test also Python 3.9. Upgrade actions and OS.

Split the basic script-based test from the proper pylint test.
