### PR TITLE
Change box contamination method so will contaminate partial box vs rounding

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,7 @@
 consignment:
   boxes:
-    min: 10
-    max: 10
+    min: 100
+    max: 100
   items_per_box:
     default: 200
     air:
@@ -38,13 +38,13 @@ consignment:
     - TX Brownsville CBP
     - WA Blaine CBP
 # f280_file: F280_sample.csv
-aqim_file: aqim_box_insp_unit.csv
-#aqim_file: blank_aqim_for_testing.csv
+#aqim_file: aqim_all.csv
+aqim_file: blank_aqim_for_testing.csv
 contamination:
-  contamination_unit: item
+  contamination_unit: box
   contamination_rate:
-    distribution: beta
-    value: 0.01
+    distribution: fixed_value
+    value: 0.001
     parameters:
       # stems
       #- 0.9998207923
@@ -58,7 +58,7 @@ contamination:
       # centered at 0.7%
       #- 0.0194628
       #- 2.7609372
-  arrangement: clustered
+  arrangement: random
   clustered:
     max_contaminated_units_per_cluster: 25
     distribution: continuous
@@ -76,7 +76,7 @@ contamination:
 #       - Actinidia
 #     max_boxes: 10 # do not apply to consignments larger than
 inspection:
-  unit: item
+  unit: box
   within_box_proportion: 0.05
   sample_strategy: hypergeometric
   min_boxes: 0

--- a/pathways/consignments.py
+++ b/pathways/consignments.py
@@ -432,9 +432,9 @@ def add_contaminant_uniform_random(config, consignment):
                 contaminated_stems = math.ceil(
                     consignment.items_per_box * box_proportion
                 )
-                consignment.boxes[index].items[0:contaminated_stems].fill(1)
+                consignment.boxes[box_index].items[0:contaminated_stems].fill(1)
                 continue
-            consignment.boxes[index].items.fill(1)
+            consignment.boxes[box_index].items.fill(1)
         assert np.count_nonzero(consignment.boxes) == math.ceil(contaminated_boxes)
     elif contamination_unit in ["item", "items"]:
         contaminated_items = num_items_to_contaminate(


### PR DESCRIPTION
@wenzeslaus Here is a proposed solution to the box contamination rate being too low. This maintains rates as specified.
Also included the condition to allow blank aqim_file or f280_file values. I omitted changing blanks to None in the scenario config tables because that carries the None values over to the pandas df breaking some code to concatenate parameter value for plotting.