### PR TITLE
add bash scripts to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,5 +122,6 @@ jobs:
         pip install .
     - name: Run Bash scripts in the repository
       run: |
+        cd examples/bash
         ./bash_examples.sh
         ./generate_synthetic_F280_dataset.sh test.csv 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,4 +123,4 @@ jobs:
     - name: Run Bash scripts in the repository
       run: |
         ./bash_examples.sh
-        ./generate_synthetic_F280_dataset.sh
+        ./generate_synthetic_F280_dataset.sh test.csv 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     strategy:
-      max-parallel: 4
+      max-parallel: 2
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
@@ -120,6 +120,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .
-    - name: Basic test
+    - name: Run Bash scripts in the repository
       run: |
-        python -m pathways --num-simulations 5 --num-consignments 50 --config-file config.yml
+        ./bash_examples.sh
+        ./generate_synthetic_F280_dataset.sh

--- a/bash_examples.sh
+++ b/bash_examples.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This file contains examples of using the simulation in Bash.
+# To certain extent it will be applicable to other command lines (shells).
+# This script can run as is with root of the repo as the current directory.
+
+python -m pathways \
+    --num-simulations 100 --num-consignments 1000 --config-file tests/test_summaries/config.yml \
+    | grep -E '^slippage: [0-9\.]*$' | sed -e 's/.*=//g'
+
+python -m pathways \
+    --num-simulations 1 --num-consignments 20 --config-file tests/test_summaries/config.yml --output-file "-" \
+    | grep "F280: " | sed -e 's/F280: //g'

--- a/examples/bash/bash_examples.sh
+++ b/examples/bash/bash_examples.sh
@@ -2,12 +2,12 @@
 
 # This file contains examples of using the simulation in Bash.
 # To certain extent it will be applicable to other command lines (shells).
-# This script can run as is with root of the repo as the current directory.
+# This script can run as is in its directory in the repo.
 
 python -m pathways \
-    --num-simulations 100 --num-consignments 1000 --config-file tests/test_summaries/config.yml \
+    --num-simulations 10 --num-consignments 100 --config-file config.yml \
     | grep -E '^slippage: [0-9\.]*$' | sed -e 's/.*=//g'
 
 python -m pathways \
-    --num-simulations 1 --num-consignments 20 --config-file tests/test_summaries/config.yml --output-file "-" \
+    --num-simulations 1 --num-consignments 20 --config-file config.yml --output-file - \
     | grep "F280: " | sed -e 's/F280: //g'

--- a/examples/bash/config.yml
+++ b/examples/bash/config.yml
@@ -1,0 +1,79 @@
+consignment:
+  boxes:
+    min: 10
+    max: 10
+  items_per_box:
+    default: 200
+    air:
+      default: 200
+    maritime:
+      default: 200
+  origins:
+    - Netherlands
+    - Mexico
+    - Israel
+    - Japan
+    - New Zealand
+    - India
+    - Tanzania
+  flowers:
+    - Hyacinthus
+    - Rosa
+    - Gerbera
+    - Agapanthus
+    - Aegilops
+    - Protea
+    - Liatris
+    - Mokara
+    - Anemone
+    - Actinidia
+  ports:
+    - NY JFK CBP
+    - FL Miami Air CBP
+    - HI Honolulu CBP
+    - AZ Phoenix CBP
+    - VA Dulles CBP
+    - CA San Francisco CBP
+    - WA Seattle Air CBP
+    - TX Brownsville CBP
+    - WA Blaine CBP
+contamination:
+  contamination_unit: item
+  contamination_rate:
+    distribution: beta
+    value: 0.01
+    parameters:
+      - 0.243875716307
+      - 223.427186223
+  arrangement: clustered
+  clustered:
+    max_contaminated_units_per_cluster: 25
+    distribution: continuous
+    random:
+      max_cluster_item_width: 100
+  random_box:
+    probability: 0.2
+    ratio: 0.5
+release_programs:
+  naive_cfrp:
+    flowers:
+    - Hyacinthus
+    - Gerbera
+    - Rosa
+    - Actinidia
+    max_boxes: 10  # do not apply to consignments larger than
+inspection:
+  unit: item
+  within_box_proportion: 0.05
+  sample_strategy: hypergeometric
+  min_boxes: 0
+  proportion:
+    value: 0.02
+  hypergeometric:
+    detection_level: 0.1
+    confidence_level: 0.95
+  fixed_n: 10
+  selection_strategy: random
+  cluster:
+    cluster_selection: cluster
+    interval: 5

--- a/examples/bash/generate_synthetic_F280_dataset.sh
+++ b/examples/bash/generate_synthetic_F280_dataset.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+# This script is used to generate a simplified fully synthetic F280 dataset.
 
 if [ -z "$1" ] || [ -z "$2" ]
   then

--- a/pathways/consignments.py
+++ b/pathways/consignments.py
@@ -98,7 +98,18 @@ class Consignment(collections.UserDict):
         :param port: string
         :param pathway: string
         """
-        super().__init__()
+        super().__init__(
+            flower=flower,
+            num_items=num_items,
+            items=items,
+            items_per_box=items_per_box,
+            num_boxes=num_boxes,
+            date=date,
+            boxes=boxes,
+            origin=origin,
+            port=port,
+            pathway=pathway,
+        )
         self.flower = flower
         self.num_items = num_items
         self.items = items

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-python -m pathways --num-simulations 100 --num-consignments 1000 --config-file config.yml \
-    | grep -E '^slippage: [0-9\.]*$' | sed -e 's/.*=//g'
-
-python -m pathways --num-simulations 1 --num-consignments 20 --config-file config.yml --output-file "-" \
-    | grep "F280: " | sed -e 's/F280: //g'


### PR DESCRIPTION
- Add Bash scripts to CI
- Fix consignment so that it works with outputs which still use the dict syntax
- Bash script in a separate examples directory with their own config file
