### PR TITLE
Add doc for running the simulation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,7 +33,7 @@ Get all command line options for the simulation by running:
 python -m pathways --help
 ```
 
-## Post processing the output
+## Post-processing the output
 
 The following sample script included in the repository shows simple
 runs of the simulation with predefined values
@@ -41,7 +41,7 @@ covering both success rate in detection of contaminants and generation of F280
 records:
 
 ```
-./run.sh
+./examples/bash/bash_examples.sh
 ```
 
 ---

--- a/docs/inspections.md
+++ b/docs/inspections.md
@@ -224,4 +224,4 @@ release_programs:
 
 ---
 
-Next: [Outputs](outputs.md)
+Next: [Outputs](run.md)

--- a/docs/run.md
+++ b/docs/run.md
@@ -1,0 +1,22 @@
+# Running the simulation
+
+There are two basic ways are a Python package and command line interface. Both interfaces take simulation parameters as a configuration file and several other user inputs as function arguments or command line arguments.
+
+The configuration file contains all parameters needed for a single simulation run
+and most of the documentation refers to it. The configuration format is YAML which is both human and machine readable and writable and JSON is supported as an alternative. The configuration file consists of a set of key and value pairs, which specify the parameters used for consignment generation, contamination, and inspection.
+The configuration file must be provided as a function or command line argument, along with the number consignments and stochastic runs to simulate.
+
+You can either use the package from the command line or Python.
+While calling the functions in Python is flexible and advantageous for incorporating the simulation in a larger analytical workflow, the command line interface is straightforward and useful for exploring different behaviors of the consignment inspections or the simulation itself.
+Python API is documented in docstrings (available in code or through Python help function). For running simulation in the command line,
+see a dedicated [CLI page](cli.md) in this documentation.
+
+For running many scenarios at once, a Python function, `pathways.scenarios.run_scenarios` is provided which in addition to the YAML configuration file also takes a table as a CSV file where each line represents one scenario and modifies the values in the configuration file. The CSV column names determine which parts of the YAML configuration file are set or replaced. Nested keys are specified using forward slashes (`key/subkey/subsubkey`). The values can use JSON syntax to specify lists or nested values (e.g., `[1, 2]`). The values returned from the function can be used for further processing or visualization in Python. Alternatively, these can be saved to a file using Python and processed elsewhere.
+
+Example scripts and (Jupyter) notebooks are included in the code repository.
+The notebooks are extremely useful for visualization of the simulation outcomes.
+You can try the notebooks online without any instalation using [Binder](binder.md).
+
+---
+
+Next: [Outputs](outputs.md)

--- a/docs/run.md
+++ b/docs/run.md
@@ -1,17 +1,16 @@
 # Running the simulation
 
-There are two basic ways are a Python package and command line interface. Both interfaces take simulation parameters as a configuration file and several other user inputs as function arguments or command line arguments.
+The two basic ways to run the simulation are a Python package and command line interface. Both interfaces take simulation parameters as a configuration file and several other user inputs as function arguments or command line arguments.
 
-The configuration file contains all parameters needed for a single simulation run
-and most of the documentation refers to it. The configuration format is YAML which is both human and machine readable and writable and JSON is supported as an alternative. The configuration file consists of a set of key and value pairs, which specify the parameters used for consignment generation, contamination, and inspection.
-The configuration file must be provided as a function or command line argument, along with the number consignments and stochastic runs to simulate.
+The configuration file contains all parameters needed for a single simulation run. The package documentation explains the configuration parameters in detail. The configuration format is YAML which is both human and machine readable and writable and JSON is supported as an alternative. The configuration file consists of a set of key and value pairs, which specify the parameters used for consignment generation, contamination, and inspection.
+The path to the configuration file must be provided as a function or command line argument, along with the number consignments and stochastic runs to simulate.
 
-You can either use the package from the command line or Python.
+You can use the package from either the command line or Python.
 While calling the functions in Python is flexible and advantageous for incorporating the simulation in a larger analytical workflow, the command line interface is straightforward and useful for exploring different behaviors of the consignment inspections or the simulation itself.
 Python API is documented in docstrings (available in code or through Python help function). For running simulation in the command line,
 see a dedicated [CLI page](cli.md) in this documentation.
 
-For running many scenarios at once, a Python function, `pathways.scenarios.run_scenarios` is provided which in addition to the YAML configuration file also takes a table as a CSV file where each line represents one scenario and modifies the values in the configuration file. The CSV column names determine which parts of the YAML configuration file are set or replaced. Nested keys are specified using forward slashes (`key/subkey/subsubkey`). The values can use JSON syntax to specify lists or nested values (e.g., `[1, 2]`). The values returned from the function can be used for further processing or visualization in Python. Alternatively, these can be saved to a file using Python and processed elsewhere.
+For running many scenarios at once, a Python function, `pathways.scenarios.run_scenarios` is provided which in addition to the YAML configuration file also takes a table of scenario configurations as a CSV file. Each row in the scenario table represents one scenario and each column contains the configuration parameter values to be modified. The CSV column names determine which parts (keys) of the YAML configuration file are modified. Nested keys are specified using forward slashes (`key/subkey/subsubkey`). The values can use JSON syntax to specify lists or nested values (e.g., `[1, 2]`). The values returned from the function can be used for further processing or visualization in Python. Alternatively, these can be saved to a file using Python and processed elsewhere.
 
 Example scripts and (Jupyter) notebooks are included in the code repository.
 The notebooks are extremely useful for visualization of the simulation outcomes.

--- a/docs/run.md
+++ b/docs/run.md
@@ -5,7 +5,8 @@ The two basic ways to run the simulation are a Python package and command line i
 The configuration file contains all parameters needed for a single simulation run. The package documentation explains the configuration parameters in detail. The configuration format is YAML which is both human and machine readable and writable and JSON is supported as an alternative. The configuration file consists of a set of key and value pairs, which specify the parameters used for consignment generation, contamination, and inspection.
 The path to the configuration file must be provided as a function or command line argument, along with the number consignments and stochastic runs to simulate.
 
-You can use the package from either the command line or Python.
+You can use the package from the command line (using the command line interface
+of the Python package) or directly from Python (within an IDE or Jupyter Notebook).
 While calling the functions in Python is flexible and advantageous for incorporating the simulation in a larger analytical workflow, the command line interface is straightforward and useful for exploring different behaviors of the consignment inspections or the simulation itself.
 Python API is documented in docstrings (available in code or through Python help function). For running simulation in the command line,
 see a dedicated [CLI page](cli.md) in this documentation.

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -5,6 +5,9 @@ types of results it can give, and other use cases.
 
 ## Synthetic F280 records
 
+Datasets like this one can be generated in case synthetic data with certain
+properties or without privacy issues are needed:
+
 | Date | Port | Origin | Flower | Action |
 | ---- | ---- | ------ | ------ | ------ |
 | 1 | RDU | Estonia | Gloriosa | RELEASE |
@@ -16,14 +19,16 @@ types of results it can give, and other use cases.
 | 5 | Miami | Taiwan | Gladiolus | PROHIBIT |
 | 5 | RDU | Estonia | Aegilops | RELEASE |
 
-### Will we intercept a new pest?
+Example workflow is included in [Obtaining synthetic F280 records](synthetic_f280.md).
+
+## Will we intercept a new pest?
 
 Using a given system of border controls, will we intercept a new pest?
 In this case, we would modify the parameters how pests in shipments from
 a particular part of the world are added, e.g. by increasing their
 probability, based on another model projecting immersion of such pest.
 
-### How sensitive are our interception tests to level of infestation?
+## How sensitive are our interception tests to level of infestation?
 
 Given a specific set of import rules, how much pest needs to be present
 in the shipments for us to detect it? Additionally, how much pest needs
@@ -47,7 +52,7 @@ infested shipment.
 | 10%            | 77%    |
 
 
-### Does a new import rule increase chance of missing a pest?
+## Does a new import rule increase chance of missing a pest?
 
 With a given (example) configuration of the shipment generation and
 the CFRP, we can get a table like this relating number of flowers in
@@ -91,18 +96,24 @@ in each shipment, our chances of detecting the pest increase:
 | 4     | 15%    |
 | 5     | 12%    |
 
-### How much pest is in the real shipments?
+## How much pest is in the real shipments?
 
 Given known import rules and sampling rates and the actual collected
 data, how much pest is present in the actual shipments? By comparing the actual
 collected data and the simulated results, we can determine, for given
 sampling rates, how much pest is present in the actual shipments.
 
-### Is is better to inspect more shipments or a random box?
+## Is is better to inspect more shipments or a random box?
 
 Is our detection rate higher when we pick a random (randomly sampled)
 box in fewer amount of shipments or when we just look at a box on
 top (an easily accessible one) in more (or all) shipments?
+
+## See also
+
+* Jupyter Notebooks, Python scripts, and Bash scripts included in the repository
+* [Obtaining synthetic F280 records](synthetic_f280.md)
+* [Outputs](outputs.md)
 
 ---
 

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -3,8 +3,7 @@
 Here are examples of questions this tool can help to answer,
 types of results it can give, and other use cases.
 
-## What is the approximate contamination rate of a set of inspected
-consignments?
+## What is the approximate contamination rate of a set of inspected consignments?
 
 Given known inspection protocols (sample size and selection method) and
 records containing the inpsection outcomes, what is the approxiamte
@@ -19,10 +18,9 @@ in the actual consignments.
 Given assumed contamination rates and consignment sizes, what percentage
 of contaminates are not being intercepted by border inspections when using
 various inspection methods? This information could be useful for estimating
-propagule pressure for quarantine significant pest species.
+propagule pressure for quarantine-significant pest species.
 
-## what are the trade offs between effort and effectiveness for
-various inspection protocols?
+## what are the trade offs between effort and effectiveness for various inspection protocols?
 
 For example, is the inspection success rate higher when we isnpect fewer
 consignments using hypergeometric random sampling, or when we inspect

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -3,7 +3,61 @@
 Here are examples of questions this tool can help to answer,
 types of results it can give, and other use cases.
 
-## Synthetic F280 records
+## What is the approximate contamination rate of a set of inspected
+consignments?
+
+Given known inspection protocols (sample size and selection method) and
+records containing the inpsection outcomes, what is the approxiamte
+contamination rate of the inspected consignments? By simulating
+inspections using the same protocol and calibrating the contamination
+parameters so that the simulated inspection outcomes match the actual
+inspection outcomes, we can estimate the contamination rate present
+in the actual consignments.
+
+## What is the approximate slippage rate for an inspection protocol?
+
+Given assumed contamination rates and consignment sizes, what percentage
+of contaminates are not being intercepted by border inspections when using
+various inspection methods? This information could be useful for estimating
+propagule pressure for quarantine significant pest species.
+
+## what are the trade offs between effort and effectiveness for
+various inspection protocols?
+
+For example, is the inspection success rate higher when we isnpect fewer
+consignments using hypergeometric random sampling, or when we inspect
+all consignments using convenience sampling?
+
+## How sensitive are the inspections to level of contamination?
+
+Given a specific inspection protocol, what level of contamination
+needs to be present in the consigments for us to detect it? Additionally,
+how much pest needs to be present to raise alarms?
+
+In the following example, we inspect two boxes of each consignment,
+each containing between 1 and 50 boxes. We run the simulation with
+different contamination rates and compare slippage rates.
+
+| Contaminated boxes | Missed |
+| ------------------ | ------ |
+| 90%                |  1%    |
+| 80%                |  4%    |
+| 70%                |  9%    |
+| 60%                | 16%    |
+| 50%                | 24%    |
+| 40%                | 34%    |
+| 30%                | 47%    |
+| 20%                | 61%    |
+| 10%                | 77%    |
+
+## Will we intercept a newly emerging pest from a specific pathway?
+
+Using a given inspection protocol, would we successfully intercept
+a newly emerging pest? In this case, we would modify the parameters
+that control how contamiantion in consignments from certain origin
+countries are added based on another model projecting an emerging pest.
+
+## Generate synthetic F280 records
 
 Datasets like this one can be generated in case synthetic data with certain
 properties or without privacy issues are needed:
@@ -21,94 +75,6 @@ properties or without privacy issues are needed:
 
 Example workflow is included in [Obtaining synthetic F280 records](synthetic_f280.md).
 
-## Will we intercept a new pest?
-
-Using a given system of border controls, will we intercept a new pest?
-In this case, we would modify the parameters how pests in shipments from
-a particular part of the world are added, e.g. by increasing their
-probability, based on another model projecting immersion of such pest.
-
-## How sensitive are our interception tests to level of infestation?
-
-Given a specific set of import rules, how much pest needs to be present
-in the shipments for us to detect it? Additionally, how much pest needs
-to be present to raise alarms?
-
-In the following example, we were checking two boxes of each shipment,
-one shipment contained between 1 and 50 boxes and CRFP was not active.
-We ran the simulations with different ratio of infested boxes in one
-infested shipment.
-
-| Infested boxes | Missed |
-| -------------- | ------ |
-| 90%            |  1%    |
-| 80%            |  4%    |
-| 70%            |  9%    |
-| 60%            | 16%    |
-| 50%            | 24%    |
-| 40%            | 34%    |
-| 30%            | 47%    |
-| 20%            | 61%    |
-| 10%            | 77%    |
-
-
-## Does a new import rule increase chance of missing a pest?
-
-With a given (example) configuration of the shipment generation and
-the CFRP, we can get a table like this relating number of flowers in
-CFRP and percentage of shipments with undiscovered pests
-(total number of flowers is 6):
-
-| Flowers | Missed |
-| ------- | ------ |
-| 0       | 24%    |
-| 1       | 24%    |
-| 2       | 26%    |
-| 3       | 29%    |
-| 4       | 31%    |
-| 5       | 33%    |
-| 6       | 36%    |
-
-If we are increasing the maximum number of boxes we don't check as part
-of CFRP (i.e. we check all above that size), we also increase the
-percentage of shipments with undiscovered pests:
-
-| Boxes | Missed |
-| ----- | ------ |
-| 0     | 24%    |
-| 1     | 24%    |
-| 2     | 25%    |
-| 5     | 28%    |
-| 10    | 31%    |
-| 20    | 39%    |
-| inf   | 62%    |
-
-With a given ratio of boxes with pest in a shipment with pests
-(here 50%, but active CFRP), if we increase number of boxes we inspect
-in each shipment, our chances of detecting the pest increase:
-
-| Boxes | Missed |
-| ----- | ------ |
-| 0     | 100%   |
-| 1     | 54%    |
-| 2     | 31%    |
-| 3     | 20%    |
-| 4     | 15%    |
-| 5     | 12%    |
-
-## How much pest is in the real shipments?
-
-Given known import rules and sampling rates and the actual collected
-data, how much pest is present in the actual shipments? By comparing the actual
-collected data and the simulated results, we can determine, for given
-sampling rates, how much pest is present in the actual shipments.
-
-## Is is better to inspect more shipments or a random box?
-
-Is our detection rate higher when we pick a random (randomly sampled)
-box in fewer amount of shipments or when we just look at a box on
-top (an easily accessible one) in more (or all) shipments?
-
 ## See also
 
 * Jupyter Notebooks, Python scripts, and Bash scripts included in the repository
@@ -117,4 +83,4 @@ top (an easily accessible one) in more (or all) shipments?
 
 ---
 
-Next: [Shipments](shipments.md)
+Next: [Consignments](consignments.md)


### PR DESCRIPTION
This adds documentation for running the simulation. It is mostly the intro and the other files are referenced.

The new page goes in between config of contamination and outputs in terms of the 'Next:' link.

Headings in the use cases page are now fixed and the synthetic F280 page is linked from there
(all pages should be now linked from somewhere).
